### PR TITLE
Fix IS_HEX_DIGIT_GROKKABLE parentheses, ASCII_TO_DIGIT API, and Makefile .PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PREFIX  ?= /usr/local
 #CFLAGS += -Wall -std=c99 -pedantic
 CFLAGS += -Wall -std=c11 -pedantic
 
-.PHONY:
+.PHONY: all
 all: test
 
 .PHONY: readme_update
@@ -24,15 +24,15 @@ format:
 	clang-format -i *.c
 	clang-format -i *.h
 
-.PHONY:
+.PHONY: test
 test: test.c char-utils.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -o test test.c
 	./test
 
-.PHONY:
+.PHONY: %.o
 %.o: %.c
 	$(CC) $(DEP_FLAG) $(CFLAGS) $(LDFLAGS) -o $@ -c $<
 
-.PHONY:
+.PHONY: clean
 clean:
 	rm -f test

--- a/char-utils.h
+++ b/char-utils.h
@@ -88,7 +88,7 @@
 #define IS_UPPER_GROKKABLE(ch) ('A' <= (ch) && (ch) <= 'Z')                                                                     ///< Equivalent to isupper() from <ctype.h>
 #define IS_ALPHA_GROKKABLE(ch) (('a' <= (ch) && (ch) <= 'z') || ('A' <= (ch) && (ch) <= 'Z'))                                   ///< Equivalent to isalpha() from <ctype.h>
 #define IS_ALNUM_GROKKABLE(ch) (('0' <= (ch) && (ch) <= '9') || ('a' <= (ch) && (ch) <= 'z') || ('A' <= (ch) && (ch) <= 'Z'))   ///< Equivalent to isalnum() from <ctype.h>
-#define IS_HEX_DIGIT_GROKKABLE(ch) ('0' <= (ch) && (ch) <= '9') || ('a' <= (ch) && (ch) <= 'f') || ('A' <= (ch) && (ch) <= 'F') ///< Equivalent to isxdigit() from <ctype.h>
+#define IS_HEX_DIGIT_GROKKABLE(ch) (('0' <= (ch) && (ch) <= '9') || ('a' <= (ch) && (ch) <= 'f') || ('A' <= (ch) && (ch) <= 'F')) ///< Equivalent to isxdigit() from <ctype.h>
 #define IS_PRINTABLE_GROKKABLE(ch) (' ' <= (ch) && (ch) <= '~')                                                                 ///< Equivalent to isprint() from <ctype.h>
 
 /* ==========================
@@ -121,7 +121,7 @@
 #define FAST_ASCII_TO_OCTAL(ch) ((ch) - '0')
 #define FAST_OCTAL_TO_ASCII(num) ((num) + '0')
 
-#define ASCII_TO_DIGIT(ch) (('0' <= (ch) && (ch) <= '9') ? ((ch) - '0') : -1) ///< Similar to strtol() from <ctype.h>
+#define ASCII_TO_DIGIT(ch, DEFAULT) (('0' <= (ch) && (ch) <= '9') ? ((ch) - '0') : DEFAULT) ///< Similar to strtol() from <ctype.h>
 #define DIGIT_TO_ASCII(num, DEFAULT) ((unsigned)(num) < 10 ? ((num) + '0') : DEFAULT)
 #define FAST_DIGIT_TO_ASCII(num) ((num) + '0')
 #define FAST_ASCII_TO_DIGIT(ch) ((ch) - '0')

--- a/test.c
+++ b/test.c
@@ -264,18 +264,18 @@ void test_conversions(void)
     assert(FAST_OCTAL_TO_ASCII(7) == '7');
 
     /* ASCII <-> DIGIT */
-    assert(ASCII_TO_DIGIT('0') == 0);
-    assert(ASCII_TO_DIGIT('1') == 1);
-    assert(ASCII_TO_DIGIT('2') == 2);
-    assert(ASCII_TO_DIGIT('3') == 3);
-    assert(ASCII_TO_DIGIT('4') == 4);
-    assert(ASCII_TO_DIGIT('5') == 5);
-    assert(ASCII_TO_DIGIT('6') == 6);
-    assert(ASCII_TO_DIGIT('7') == 7);
-    assert(ASCII_TO_DIGIT('8') == 8);
-    assert(ASCII_TO_DIGIT('9') == 9);
-    assert(ASCII_TO_DIGIT('\0') == -1);
-    assert(ASCII_TO_DIGIT('X') == -1);
+    assert(ASCII_TO_DIGIT('0', -1) == 0);
+    assert(ASCII_TO_DIGIT('1', -1) == 1);
+    assert(ASCII_TO_DIGIT('2', -1) == 2);
+    assert(ASCII_TO_DIGIT('3', -1) == 3);
+    assert(ASCII_TO_DIGIT('4', -1) == 4);
+    assert(ASCII_TO_DIGIT('5', -1) == 5);
+    assert(ASCII_TO_DIGIT('6', -1) == 6);
+    assert(ASCII_TO_DIGIT('7', -1) == 7);
+    assert(ASCII_TO_DIGIT('8', -1) == 8);
+    assert(ASCII_TO_DIGIT('9', -1) == 9);
+    assert(ASCII_TO_DIGIT('\0', -1) == -1);
+    assert(ASCII_TO_DIGIT('X', -1) == -1);
 
     assert(DIGIT_TO_ASCII(0, -1) == '0');
     assert(DIGIT_TO_ASCII(1, -1) == '1');


### PR DESCRIPTION
- IS_HEX_DIGIT_GROKKABLE was missing outer parentheses, causing incorrect
  evaluation when negated or used in compound expressions (e.g. !IS_HEX_DIGIT_GROKKABLE(x))
- ASCII_TO_DIGIT now takes an explicit DEFAULT parameter, consistent with
  ASCII_TO_BINARY and ASCII_TO_OCTAL; update test.c callers accordingly
- .PHONY declarations in Makefile now correctly name their target (all, test, clean)

https://claude.ai/code/session_01KgmvFygcdVrZaqaGMQ12uM