### PR TITLE
Fix macro bugs, API consistency, and bump to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # char-utils
 
-<versionBadge>![Version 0.4.0](https://img.shields.io/badge/version-0.4.0-blue.svg)</versionBadge>
+<versionBadge>![Version 0.5.0](https://img.shields.io/badge/version-0.5.0-blue.svg)</versionBadge>
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![C](https://img.shields.io/badge/Language-C-blue.svg)](https://en.wikipedia.org/wiki/C_(programming_language))
 [![CI/CD Status Badge](https://github.com/mofosyne/char-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/mofosyne/char-utils/actions)

--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "char-utils",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repo": "mofosyne/char-utils.h",
   "description": "Small C utility library macros and functions for char handling. e.g. conversion or checks for hex, digits and ascii values",
   "keywords": ["char", "ascii", "macros", "hex", "digits"],


### PR DESCRIPTION
## Summary

- **Bug fix**: `IS_HEX_DIGIT_GROKKABLE` was missing outer parentheses, causing incorrect evaluation when negated or used in compound expressions (e.g. `!IS_HEX_DIGIT_GROKKABLE(x)`)
- **Breaking API fix**: `ASCII_TO_DIGIT` now takes an explicit `DEFAULT` parameter, consistent with `ASCII_TO_BINARY` and `ASCII_TO_OCTAL`
- **Makefile fix**: `.PHONY` declarations now correctly name their targets (`all`, `test`, `%.o`, `clean`)
- **Version bump**: 0.4.0 → 0.5.0 to reflect the breaking `ASCII_TO_DIGIT` API change

## Test plan

- [ ] `make test` passes (all character check, case conversion, and conversion tests)
- [ ] CI passes on this PR
- [ ] Callers of `ASCII_TO_DIGIT` updated to two-argument form in `test.c`

https://claude.ai/code/session_01KgmvFygcdVrZaqaGMQ12uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgmvFygcdVrZaqaGMQ12uM)_