### PR TITLE
Improve ascii_to_diagnostics API and add README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,97 @@ or copy these files manually to your source folder:
 ```bash
 char-utils.h
 ```
+
+## Examples
+
+```c
+#include "char-utils.h"
+
+/* Character type checks */
+if (IS_DIGIT(c))   { /* '0'-'9' */ }
+if (IS_HEX_DIGIT(c)) { /* '0'-'9', 'a'-'f', 'A'-'F' */ }
+if (IS_ALPHA(c))   { /* 'a'-'z', 'A'-'Z' */ }
+if (IS_SPACE(c))   { /* ' ', '\t', '\n', '\r', '\f', '\v' */ }
+
+/* Conversions */
+int digit = ASCII_TO_DIGIT(c, -1);       /* '7' -> 7, invalid -> -1 */
+int hex   = HEX_TO_INT(c, -1);           /* 'F' -> 15, invalid -> -1 */
+char upper = TO_UPPER(c);                /* 'a' -> 'A', non-alpha unchanged */
+char lo_hex = NIBBLE_TO_LOWERCASE_HEX(n, '?'); /* 10 -> 'a' */
+
+/* Nibble splitting */
+uint8_t hi = HIGH_NIBBLE(byte);          /* 0xAB -> 0xA */
+uint8_t lo = LOW_NIBBLE(byte);           /* 0xAB -> 0xB */
+
+/* ASCII diagnostics (safe with getchar() return value) */
+int c = getchar();
+printf("%s\n", ascii_to_diagnostics(c, "[EOF]")); /* prints e.g. "[LF]" or "A" */
+```
+
+## API
+
+Each safe macro accepts an explicit `DEFAULT` value returned on invalid input.
+`FAST_` variants skip validation and are suitable when input is already known-good.
+
+### Character Type Checks
+
+| Macro | Equivalent | Description |
+|---|---|---|
+| `IS_BINARY(ch)` | — | `'0'` or `'1'` |
+| `IS_OCTAL(ch)` | — | `'0'`–`'7'` |
+| `IS_DIGIT(ch)` | `isdigit()` | `'0'`–`'9'` |
+| `IS_LOWER(ch)` | `islower()` | `'a'`–`'z'` |
+| `IS_UPPER(ch)` | `isupper()` | `'A'`–`'Z'` |
+| `IS_ALPHA(ch)` | `isalpha()` | `'a'`–`'z'`, `'A'`–`'Z'` |
+| `IS_ALNUM(ch)` | `isalnum()` | alphanumeric |
+| `IS_HEX_DIGIT(ch)` | `isxdigit()` | `'0'`–`'9'`, `'a'`–`'f'`, `'A'`–`'F'` |
+| `IS_PRINTABLE(ch)` | `isprint()` | `' '`–`'~'` |
+| `IS_SPACE(ch)` | `isspace()` | whitespace (C locale) |
+| `IS_PUNCT(ch)` | `ispunct()` | printable, non-alnum, non-space |
+| `IS_BRACKET(ch)` | — | `(`, `)`, `[`, `]`, `{`, `}` |
+| `IS_SYMBOL(ch)` | — | printable punct, non-bracket |
+| `IS_ASCII(ch)` | — | `0`–`127` |
+| `IS_EXTENDED_ASCII(ch)` | — | `0`–`255` |
+
+Each has a `_GROKKABLE` variant with explicit range comparisons for readability.
+
+### Case Conversion
+
+| Macro | Description |
+|---|---|
+| `TO_UPPER(ch)` | Lower to upper, non-alpha unchanged |
+| `TO_LOWER(ch)` | Upper to lower, non-alpha unchanged |
+| `TOGGLE_CASE(ch)` | Flip case, non-alpha unchanged |
+| `FAST_TO_UPPER(ch)` | Bit-clear, no guard |
+| `FAST_TO_LOWER(ch)` | Bit-set, no guard |
+| `FAST_TOGGLE_CASE(ch)` | Bit-flip, no guard |
+
+### Digit & Hex Conversion
+
+| Macro | Description |
+|---|---|
+| `ASCII_TO_DIGIT(ch, DEFAULT)` | `'0'`–`'9'` → 0–9 |
+| `DIGIT_TO_ASCII(n, DEFAULT)` | 0–9 → `'0'`–`'9'` |
+| `ASCII_TO_BINARY(ch, DEFAULT)` | `'0'`/`'1'` → 0/1 |
+| `ASCII_TO_OCTAL(ch, DEFAULT)` | `'0'`–`'7'` → 0–7 |
+| `HEX_TO_INT(ch, DEFAULT)` | hex char → 0–15 |
+| `NIBBLE_TO_UPPERCASE_HEX(n, DEFAULT)` | 0–15 → `'0'`–`'F'` |
+| `NIBBLE_TO_LOWERCASE_HEX(n, DEFAULT)` | 0–15 → `'0'`–`'f'` |
+
+`FAST_` variants available for all of the above.
+
+### Nibble Operations
+
+| Macro | Description |
+|---|---|
+| `HIGH_NIBBLE(byte)` | Upper 4 bits |
+| `LOW_NIBBLE(byte)` | Lower 4 bits |
+
+### ASCII Diagnostics
+
+```c
+const char *ascii_to_diagnostics(int ch, const char *default_str);
+```
+
+Returns a human-readable string for any byte value (e.g. `"[LF]"`, `"[NUL]"`, `"A"`).
+Accepts the `int` return type of `getchar()`/`fgetc()` directly; returns `default_str` for values outside 0–255.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # char-utils
 
-<versionBadge>![Version 0.5.0](https://img.shields.io/badge/version-0.5.0-blue.svg)</versionBadge>
+<versionBadge>![Version 0.6.0](https://img.shields.io/badge/version-0.6.0-blue.svg)</versionBadge>
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![C](https://img.shields.io/badge/Language-C-blue.svg)](https://en.wikipedia.org/wiki/C_(programming_language))
 [![CI/CD Status Badge](https://github.com/mofosyne/char-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/mofosyne/char-utils/actions)

--- a/char-utils.h
+++ b/char-utils.h
@@ -28,6 +28,8 @@
 #ifndef CHAR_UTILS_H
 #define CHAR_UTILS_H
 
+#include <stddef.h> /* NULL */
+
 /* Design Notes:
  * The below macros are focused on being compact even if optimisation is
  * disabled by relying only on arithmic operation and comparison, rather
@@ -144,8 +146,10 @@
 /* ==========================
  * ASCII Diagnostic
  * ========================== */
-static inline const char *ascii_to_diagnostics(unsigned char ch)
+static inline const char *ascii_to_diagnostics(int ch)
 {
+    if ((unsigned)ch > 255)
+        return NULL;
     static const char *ascii_lut[256] = {
         "[NUL]",  "[SOH]",  "[STX]",  "[ETX]",  "[EOT]",  "[ENQ]",  "[ACK]",  "[BEL]",  "[BS]",   "[TAB]",  "[LF]",   "[VT]",   "[FF]",   "[CR]",   "[SO]",   "[SI]",   "[DLE]",  "[DC1]",  "[DC2]",
         "[DC3]",  "[DC4]",  "[NAK]",  "[SYN]",  "[ETB]",  "[CAN]",  "[EM]",   "[SUB]",  "[ESC]",  "[FS]",   "[GS]",   "[RS]",   "[US]",   " ",      "!",      "\"",     "#",      "$",      "%",
@@ -161,7 +165,7 @@ static inline const char *ascii_to_diagnostics(unsigned char ch)
         "[0xD1]", "[0xD2]", "[0xD3]", "[0xD4]", "[0xD5]", "[0xD6]", "[0xD7]", "[0xD8]", "[0xD9]", "[0xDA]", "[0xDB]", "[0xDC]", "[0xDD]", "[0xDE]", "[0xDF]", "[0xE0]", "[0xE1]", "[0xE2]", "[0xE3]",
         "[0xE4]", "[0xE5]", "[0xE6]", "[0xE7]", "[0xE8]", "[0xE9]", "[0xEA]", "[0xEB]", "[0xEC]", "[0xED]", "[0xEE]", "[0xEF]", "[0xF0]", "[0xF1]", "[0xF2]", "[0xF3]", "[0xF4]", "[0xF5]", "[0xF6]",
         "[0xF7]", "[0xF8]", "[0xF9]", "[0xFA]", "[0xFB]", "[0xFC]", "[0xFD]", "[0xFE]", "[0xFF]"};
-    return ascii_lut[ch];
+    return ascii_lut[(unsigned char)ch];
 }
 
 #endif // CHAR_UTILS_H

--- a/char-utils.h
+++ b/char-utils.h
@@ -145,10 +145,10 @@
 /* ==========================
  * ASCII Diagnostic
  * ========================== */
-static inline const char *ascii_to_diagnostics(int ch)
+static inline const char *ascii_to_diagnostics(int ch, const char *default_str)
 {
     if ((unsigned)ch > 255)
-        return 0;
+        return default_str;
     static const char *ascii_lut[256] = {
         "[NUL]",  "[SOH]",  "[STX]",  "[ETX]",  "[EOT]",  "[ENQ]",  "[ACK]",  "[BEL]",  "[BS]",   "[TAB]",  "[LF]",   "[VT]",   "[FF]",   "[CR]",   "[SO]",   "[SI]",   "[DLE]",  "[DC1]",  "[DC2]",
         "[DC3]",  "[DC4]",  "[NAK]",  "[SYN]",  "[ETB]",  "[CAN]",  "[EM]",   "[SUB]",  "[ESC]",  "[FS]",   "[GS]",   "[RS]",   "[US]",   " ",      "!",      "\"",     "#",      "$",      "%",

--- a/char-utils.h
+++ b/char-utils.h
@@ -28,7 +28,6 @@
 #ifndef CHAR_UTILS_H
 #define CHAR_UTILS_H
 
-#include <stddef.h> /* NULL */
 
 /* Design Notes:
  * The below macros are focused on being compact even if optimisation is
@@ -149,7 +148,7 @@
 static inline const char *ascii_to_diagnostics(int ch)
 {
     if ((unsigned)ch > 255)
-        return NULL;
+        return 0;
     static const char *ascii_lut[256] = {
         "[NUL]",  "[SOH]",  "[STX]",  "[ETX]",  "[EOT]",  "[ENQ]",  "[ACK]",  "[BEL]",  "[BS]",   "[TAB]",  "[LF]",   "[VT]",   "[FF]",   "[CR]",   "[SO]",   "[SI]",   "[DLE]",  "[DC1]",  "[DC2]",
         "[DC3]",  "[DC4]",  "[NAK]",  "[SYN]",  "[ETB]",  "[CAN]",  "[EM]",   "[SUB]",  "[ESC]",  "[FS]",   "[GS]",   "[RS]",   "[US]",   " ",      "!",      "\"",     "#",      "$",      "%",

--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "char-utils",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repo": "mofosyne/char-utils.h",
   "description": "Small C utility library macros and functions for char handling. e.g. conversion or checks for hex, digits and ascii values",
   "keywords": ["char", "ascii", "macros", "hex", "digits"],

--- a/test.c
+++ b/test.c
@@ -452,14 +452,15 @@ int main()
     test_case_conversion();
     test_conversions();
 
-    /* ascii_to_diagnostics: valid range 0-255, NULL outside */
+    /* ascii_to_diagnostics: valid range 0-255, default_str outside */
     for (int i = 0; i < 256; i++)
     {
-        assert(ascii_to_diagnostics(i) != NULL);
-        printf("ASCII %3d = 0x%2X: %s\n", i, i, ascii_to_diagnostics(i));
+        assert(ascii_to_diagnostics(i, NULL) != NULL);
+        printf("ASCII %3d = 0x%2X: %s\n", i, i, ascii_to_diagnostics(i, "[INVALID]"));
     }
-    assert(ascii_to_diagnostics(-1) == NULL);   /* EOF */
-    assert(ascii_to_diagnostics(256) == NULL);  /* out of range */
+    assert(ascii_to_diagnostics(-1, NULL) == NULL);      /* EOF */
+    assert(ascii_to_diagnostics(256, NULL) == NULL);     /* out of range */
+    assert(ascii_to_diagnostics(-1, "[EOF]") != NULL);   /* custom default */
 
     printf("All tests passed successfully!\n");
     return 0;

--- a/test.c
+++ b/test.c
@@ -452,10 +452,14 @@ int main()
     test_case_conversion();
     test_conversions();
 
+    /* ascii_to_diagnostics: valid range 0-255, NULL outside */
     for (int i = 0; i < 256; i++)
     {
+        assert(ascii_to_diagnostics(i) != NULL);
         printf("ASCII %3d = 0x%2X: %s\n", i, i, ascii_to_diagnostics(i));
     }
+    assert(ascii_to_diagnostics(-1) == NULL);   /* EOF */
+    assert(ascii_to_diagnostics(256) == NULL);  /* out of range */
 
     printf("All tests passed successfully!\n");
     return 0;


### PR DESCRIPTION
## Summary

- **`ascii_to_diagnostics` signature**: parameter changed from `unsigned char` to `int`, matching `<ctype.h>` convention so callers can pass `getchar()`/`fgetc()` return values directly without a cast
- **Out-of-range handling**: adds `const char *default_str` parameter (consistent with `ASCII_TO_DIGIT`, `HEX_TO_INT`, etc.) returned for values outside 0–255 — safe for direct use in `printf`
- **No new includes**: uses `0` as null pointer constant to preserve the header's no-includes property
- **README**: added quick-start examples section and full API reference table covering all macro groups

## Test plan

- [ ] `make test` passes
- [ ] CI passes on this PR
- [ ] `ascii_to_diagnostics(-1, NULL) == NULL` (EOF/out-of-range returns default)
- [ ] `ascii_to_diagnostics(-1, "[EOF]")` returns the custom default string

https://claude.ai/code/session_01KgmvFygcdVrZaqaGMQ12uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgmvFygcdVrZaqaGMQ12uM)_